### PR TITLE
Create new makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,88 @@
+PWD := $(shell pwd)
+
+ifeq ($(RADSAN_BUILD_DIR),)
+	BUILD_DIR := $(PWD)/build
+else
+	BUILD_DIR := $(RADSAN_BUILD_DIR)
+endif
+
+NPROCS := 1
+OS := $(shell uname -s)
+
+ifeq ($(OS),Linux)
+	NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
+endif
+ifeq ($(OS),Darwin)
+	NPROCS := $(shell sysctl -n hw.ncpu)
+endif
+
+CCACHE := $(shell which ccache)
+
+clang: generate
+	cmake --build $(BUILD_DIR) --target clang compiler-rt llvm-symbolizer -j$(NPROCS)
+	echo "\nclang output:\n" && find $(BUILD_DIR)/bin -type l | grep clang;
+
+build-folder:
+	if [ ! -d $(BUILD_DIR) ]; then \
+		mkdir -p $(BUILD_DIR); \
+	fi
+
+submodules:
+	if [ ! -f llvm-project/README.md ]; then \
+		git submodule update --init --recursive; \
+	fi
+
+generate: build-folder submodules
+	if [ ! -f $(BUILD_DIR)/CMakeCache.txt ]; then \
+		cmake -G "$${RADSAN_CMAKE_GENERATOR:-Ninja}" \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DBUILD_SHARED_LIBS=ON \
+		-DCOMPILER_RT_BUILD_SANITIZERS=ON \
+		-DLLVM_ENABLE_PROJECTS="clang;compiler-rt" \
+		-DLLVM_TARGETS_TO_BUILD=Native \
+		-DCMAKE_C_COMPILER_LAUNCHER=$(CCACHE) \
+		-DCMAKE_CXX_COMPILER_LAUNCHER=$(CCACHE) \
+		-DSANITIZER_MIN_OSX_VERSION=$${RADSAN_MIN_OSX_VERSION:-10.15} \
+		-B $(BUILD_DIR) \
+		./llvm-project/llvm; \
+	fi
+
+test-radsan: generate clang
+	cmake --build $(BUILD_DIR) --target TRadsan-arm64-NoInstTest TRadsan-arm64-Test -j$(NPROCS)
+	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-arm64-NoInstTest
+	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-arm64-Test
+
+check-compiler-rt: generate
+	cmake --build $(BUILD_DIR) --target check-compiler-rt -j$(NPROCS)
+
+docker:
+	docker build -t radsan -f $(PWD)/docker/Dockerfile .
+
+# Does not include check-compiler-rt as it is extremely slow
+test: clang test-radsan
+
+clean:
+	rm -rf $(BUILD_DIR)
+
+.PHONY: help clang build-folder submodules generate test-radsan check-compiler-rt test clean docker test-all
+
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  help              Show this help message"
+	@echo "  generate          Generate build files"
+	@echo "  clang             Build clang and compiler-rt"
+	@echo "  test-radsan       Build and run Radsan tests"
+	@echo "  check-compiler-rt Run compiler-rt tests (extremely slow)"
+	@echo "  test              Build and run radsan tests"
+	@echo "  docker            Build docker image"
+	@echo "  clean             Clean build directory"
+	@echo ""
+	@echo "Variables:"
+	@echo "  RADSAN_BUILD_DIR  Build directory (default: build)"
+	@echo "  RADSAN_CMAKE_GENERATOR  CMake generator (default: Ninja)"
+	@echo "  RADSAN_MIN_OSX_VERSION  Minimum macOS version (default: 10.15)"
+	@echo ""
+	@echo "Example:"
+	@echo "  make RADSAN_BUILD_DIR=build-clang RADSAN_CMAKE_GENERATOR=Unix\ Makefiles RADSAN_MIN_OSX_VERSION=10.14 clang"

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ submodules:
 
 generate: build-folder submodules
 	if [ ! -f $(BUILD_DIR)/CMakeCache.txt ]; then \
-		cmake -G "$${RADSAN_CMAKE_GENERATOR:-Ninja}" \
+		cmake -G "$${RADSAN_CMAKE_GENERATOR:-Unix Makefiles}" \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DBUILD_SHARED_LIBS=ON \
 		-DCOMPILER_RT_BUILD_SANITIZERS=ON \
@@ -47,7 +47,7 @@ generate: build-folder submodules
 		./llvm-project/llvm; \
 	fi
 
-test-radsan: generate clang
+test: generate clang
 	cmake --build $(BUILD_DIR) --target TRadsan-arm64-NoInstTest TRadsan-arm64-Test -j$(NPROCS)
 	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-arm64-NoInstTest
 	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-arm64-Test
@@ -58,13 +58,10 @@ check-compiler-rt: generate
 docker:
 	docker build -t radsan -f $(PWD)/docker/Dockerfile .
 
-# Does not include check-compiler-rt as it is extremely slow
-test: clang test-radsan
-
 clean:
 	rm -rf $(BUILD_DIR)
 
-.PHONY: help clang build-folder submodules generate test-radsan check-compiler-rt test clean docker test-all
+.PHONY: help clang build-folder submodules generate check-compiler-rt test clean docker test-all
 
 help:
 	@echo "Usage: make [target]"
@@ -73,16 +70,15 @@ help:
 	@echo "  help              Show this help message"
 	@echo "  generate          Generate build files"
 	@echo "  clang             Build clang and compiler-rt"
-	@echo "  test-radsan       Build and run Radsan tests"
-	@echo "  check-compiler-rt Run compiler-rt tests (extremely slow)"
+	@echo "  check-compiler-rt Run all compiler-rt tests (extremely slow)"
 	@echo "  test              Build and run radsan tests"
 	@echo "  docker            Build docker image"
 	@echo "  clean             Clean build directory"
 	@echo ""
 	@echo "Variables:"
-	@echo "  RADSAN_BUILD_DIR  Build directory (default: build)"
-	@echo "  RADSAN_CMAKE_GENERATOR  CMake generator (default: Ninja)"
+	@echo "  RADSAN_BUILD_DIR        Build directory (default: build)"
+	@echo "  RADSAN_CMAKE_GENERATOR  CMake generator (default: Unix Makefiles)"
 	@echo "  RADSAN_MIN_OSX_VERSION  Minimum macOS version (default: 10.15)"
 	@echo ""
 	@echo "Example:"
-	@echo "  make RADSAN_BUILD_DIR=build-clang RADSAN_CMAKE_GENERATOR=Unix\ Makefiles RADSAN_MIN_OSX_VERSION=10.14 clang"
+	@echo "  make RADSAN_BUILD_DIR=build-clang RADSAN_CMAKE_GENERATOR=Ninja RADSAN_MIN_OSX_VERSION=10.14 clang"

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ endif
 
 NPROCS := 1
 OS := $(shell uname -s)
+ARCH := $(shell uname -m)
 
 ifeq ($(OS),Linux)
 	NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
@@ -47,10 +48,10 @@ generate: build-folder submodules
 		./llvm-project/llvm; \
 	fi
 
-test: generate clang
-	cmake --build $(BUILD_DIR) --target TRadsan-arm64-NoInstTest TRadsan-arm64-Test -j$(NPROCS)
-	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-arm64-NoInstTest
-	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-arm64-Test
+test: generate 
+	cmake --build $(BUILD_DIR) --target TRadsan-$(ARCH)-NoInstTest TRadsan-$(ARCH)-Test -j$(NPROCS)
+	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-$(ARCH)-NoInstTest
+	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-$(ARCH)-Test
 
 check-compiler-rt: generate
 	cmake --build $(BUILD_DIR) --target check-compiler-rt -j$(NPROCS)

--- a/README.md
+++ b/README.md
@@ -110,34 +110,32 @@ llvm-project submodule. The llvm-project is a CMake project, and takes a bit of
 time to build. 
 
 To minimise this build time, we recommend using the `ninja`
-build system, and configuring with a few specific CMake settings:
+build system:
 
 ```sh
-git clone https://github.com/realtime-sanitizer/radsan && cd radsan
-git submodule update --init --recursive && cd llvm-project
-mkdir build && cd build
-cmake -G Ninja \
-   -DCMAKE_BUILD_TYPE=Release \
-   -DBUILD_SHARED_LIBS=ON \
-   -DLLVM_ENABLE_PROJECTS="clang;compiler-rt" \
-   -DLLVM_TARGETS_TO_BUILD=Native \
-   ../llvm
-ninja -j8 clang compiler-rt llvm-symbolizer
+make # run with Unix Makefiles, by default, a bit slow
+make RADSAN_CMAKE_GENERATOR=Ninja
 ```
 
-If built successfully, `clang` should have appeared inside the `bin/` folder,
-and the radsan dynamic library should be in `lib/`:
+If built successfully, the path to the `clang` binaries will be output
 
 ```sh
-> find $(pwd)/bin | grep clang
-$RADSAN_ROOT/llvm-project/build/bin/clang
-$RADSAN_ROOT/llvm-project/build/bin/clang-tblgen
-$RADSAN_ROOT/llvm-project/build/bin/clang-cl
-$RADSAN_ROOT/llvm-project/build/bin/clang++
-$RADSAN_ROOT/llvm-project/build/bin/clang-cpp
-$RADSAN_ROOT/llvm-project/build/bin/clang-18
-> find $(pwd)/lib | grep radsan
-$RADSAN_ROOT/llvm-project/build/lib/clang/18/lib/darwin/libclang_rt.radsan_osx_dynamic.dylib
+>make 
+
+...
+
+clang output:
+
+$RADSAN_ROOT/build/bin/clang
+$RADSAN_ROOT/build/bin/clang-cl
+$RADSAN_ROOT/build/bin/clang++
+$RADSAN_ROOT/build/bin/clang-cpp
+```
+
+The radsan dynamic library should be in `lib/`:
+```sh
+> find $(pwd)/build/ -name "*radsan*dylib" 
+$RADSAN_ROOT/build/lib/clang/18/lib/darwin/libclang_rt.radsan_osx_dynamic.dylib
 ```
 
 These absolute paths will be used as your C and C++ compilers, as seen in the [Usage](#usage) section.
@@ -150,7 +148,6 @@ $RADSAN_ROOT/llvm-project/build/bin/clang++ -fsanitize=realtime main.cpp
 
 Apologies, RealtimeSanitizer does not yet support Windows. We very much welcome
 contributions, so please [contact us](#contact) if you're interested.
-
 
 
 # Usage
@@ -291,7 +288,7 @@ Radsan contains a submodule with a fork of the `llvm-project`. This fork contain
 Building the Docker image locally is straightforward:
 
 ```sh
-docker build -t radsan -f docker/Dockerfile .
+make docker
 ```
 
 ## Running the tests
@@ -302,12 +299,16 @@ targets to the compiler-rt project for each architecture `arch`:
 1. `TRadsan-${arch}-Test` (which is instrumented by RADSan), and
 2. `TRadsan-${arch}-NoInstTest` (which are unit tests that do not need the RADSan instrumentation)
 
-Here's an example script for running the RADSan tests in isolation on `arm64`
-architecture. From your build folder in llvm-project:
+To run the tests:
 
 ```sh
-ninja TRadsan-arm64-Test && ./projects/compiler-rt/lib/radsan/tests/Radsan-arm64-Test
-ninja TRadsan-arm64-NoInstTest && ./projects/compiler-rt/lib/radsan/tests/Radsan-arm64-NoInstTest
+make test
+```
+
+To run the full test suite of llvm compiler-rt (very slow, may have additional unexpected failures):
+
+```sh
+make check-compiler-rt
 ```
 
 # Contact


### PR DESCRIPTION
Starting to dig into the workflow (and doing the README work yesterday) got me thinking that we should have something like this.  This is a very simple makefile that can be referenced from both the README and our workflow.

Biggest advantages are:
1. We have a living, breathing file that is the source of truth of how to build the project. There is no way of the README and the workflow file getting out of date with one another.
2. New users can get started with just one command

```
make # by default builds clang
```
3. Users cannot fat-finger or typo any command, leading to more reproducible outcomes on their side.
4. README and worfklow files can be simplified using these commands.