### PR TITLE
Add full tests to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ test: test-targets
 	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-$(ARCH)-NoInstTest
 	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-$(ARCH)-Test
 
+test-all: generate
+	cmake --build $(BUILD_DIR) --target check-radsan -j$(NPROCS)
+
 check-compiler-rt: generate
 	cmake --build $(BUILD_DIR) --target check-compiler-rt -j$(NPROCS)
 

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test: test-targets
 	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-$(ARCH)-NoInstTest
 	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-$(ARCH)-Test
 
-test-all: generate
+test-all: generate test
 	cmake --build $(BUILD_DIR) --target check-radsan -j$(NPROCS)
 
 check-compiler-rt: generate
@@ -67,7 +67,7 @@ docker:
 clean:
 	rm -rf $(BUILD_DIR)
 
-.PHONY: help clang build-folder submodules generate check-compiler-rt test clean docker test-targets
+.PHONY: help clang build-folder submodules generate check-compiler-rt test clean docker test-targets test-all
 
 help:
 	@echo "Usage: make [target]"
@@ -76,9 +76,10 @@ help:
 	@echo "  help              Show this help message"
 	@echo "  generate          Generate build files"
 	@echo "  clang             Build clang and compiler-rt"
-	@echo "  check-compiler-rt Run all compiler-rt tests (extremely slow)"
+	@echo "  check-compiler-rt Run all compiler-rt tests (extremely slow, may have failures)"
 	@echo "  test-targets      Build radsan tests"
-	@echo "  test              Build and run radsan tests"
+	@echo "  test              Run radsan tests"
+	@echo "  test-all          Run all tests, including lit (may have failures)"
 	@echo "  docker            Build docker image"
 	@echo "  clean             Clean build directory"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,6 @@ test-targets: generate
 	cmake --build $(BUILD_DIR) --target TRadsan-$(ARCH)-Test TRadsan-$(ARCH)-NoInstTest -j$(NPROCS)
 
 test: test-targets
-	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-$(ARCH)-NoInstTest
-	$(BUILD_DIR)/projects/compiler-rt/lib/radsan/tests/Radsan-$(ARCH)-Test
-
-test-all: generate test
 	cmake --build $(BUILD_DIR) --target check-radsan -j$(NPROCS)
 
 check-compiler-rt: generate
@@ -67,7 +63,7 @@ docker:
 clean:
 	rm -rf $(BUILD_DIR)
 
-.PHONY: help clang build-folder submodules generate check-compiler-rt test clean docker test-targets test-all
+.PHONY: help clang build-folder submodules generate check-compiler-rt test clean docker test-targets
 
 help:
 	@echo "Usage: make [target]"
@@ -79,7 +75,6 @@ help:
 	@echo "  check-compiler-rt Run all compiler-rt tests (extremely slow, may have failures)"
 	@echo "  test-targets      Build radsan tests"
 	@echo "  test              Run radsan tests"
-	@echo "  test-all          Run all tests, including lit (may have failures)"
 	@echo "  docker            Build docker image"
 	@echo "  clean             Clean build directory"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -305,6 +305,13 @@ To run the tests:
 make test
 ```
 
+To run all the tests, including the `lit` tests which compile test programs, run the command below. Note that not all these tests pass, some of them fail depending on the architecture of your machine.
+
+```sh
+make test-all
+```
+
+
 To run the full test suite of llvm compiler-rt (very slow, may have additional unexpected failures):
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -298,19 +298,13 @@ targets to the compiler-rt project for each architecture `arch`:
 
 1. `TRadsan-${arch}-Test` (which is instrumented by RADSan), and
 2. `TRadsan-${arch}-NoInstTest` (which are unit tests that do not need the RADSan instrumentation)
+3. The "lit tests" which compile and run tests programs from scratch (see llvm-project/compiler-rt/test/radsan/TestCases/)
 
 To run the tests:
 
 ```sh
 make test
 ```
-
-To run all the tests, including the `lit` tests which compile test programs, run the command below. Note that not all these tests pass, some of them fail depending on the architecture of your machine.
-
-```sh
-make test-all
-```
-
 
 To run the full test suite of llvm compiler-rt (very slow, may have additional unexpected failures):
 


### PR DESCRIPTION
Closes #17 .

Adjusts the `test` target so it runs all tests, including all unit tests as well as lit tests. This will be run every time we do a PR, ensuring we stay green!
