### PR TITLE
Bump llvm-project version to be based on stable release 17.0.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,6 @@ jobs:
     - name: Generate
       run: make generate
     - name: Build
-      run: make clang test-targets
+      run: make clang
     - name: Run unit tests
       run: make test


### PR DESCRIPTION
To sanity check, ensure the submodule has been bumped to this commit:

```
00ac38bcbea6 Get rid of internal symbolizer target for 17.0 release branch
```

Which should be the tip of the `realtime-sanitizer/llvm-project/radsan-llvm-17.0.6` branch.


Good to merge once tests are green.