### PR TITLE
Removed unneeded test-targets dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,6 @@ jobs:
     - name: Generate
       run: make generate
     - name: Build
-      run: make clang test-targets
+      run: make clang
     - name: Run unit tests
       run: make test


### PR DESCRIPTION
This was an accidental omission from #20, leaving the tests unable to run. This target no longer exists, so we don't need to build it. `make test` will compile and run all test targets.