### PR TITLE
Update installation instructions to point to clang 20 and pre-builts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,14 @@ Intercepted call to real-time unsafe function `malloc` in real-time context!
 
 # Getting RTSan
 
-Until LLVM 20 is shipped with your OS, you'll need to download or build it
-yourself to use RealtimeSanitizer. The easiest way to experiment with RTSan is
-with our Docker image, for which more details can be found below.
+# Using Clang 20+ (recommended)
+
+The easiest way to use RTSan is by using Clang 20 or later. Once Clang 20 is installed
+on your system, compile and link with the `-fsanitize=realtime` flag.
 
 ## Docker
 
-The fastest way to try RealtimeSanitizer is to pull the [pre-built docker
+To experiment with RealtimeSanitizer before downloading Clang 20 pull the [pre-built docker
 image](https://hub.docker.com/repository/docker/realtimesanitizer/rtsan-clang/),
 which has `clang` (and other `llvm` tooling) with RTSan readily installed.
 
@@ -97,11 +98,6 @@ or CI environment:
 FROM realtimesanitizer/rtsan-clang:latest
 RUN apt-get update && apt-get install -y git cmake vim
 ```
-
-## Building LLVM 20 from source
-
-RTSan is now part of LLVM 20; please see the build instructions
-[here](https://llvm.org/docs/CMake.html) for more information.
 
 ## Windows
 
@@ -154,11 +150,24 @@ RTSan's algorithm consists of two parts that work together:
 
 The recommended way to use RTSan is to use it with LLVM 20 directly, as described elsewhere in this document. The rest of this section describes a hack which may or may not continue to work in the future.
 
-If you are in a position where you cannot use this compiler and instead rely on AppleClang or GCC, you can still use RTSan by directly linking in the runtime in directly.
+If you are in a position where you cannot use this compiler and instead rely on AppleClang, GCC, or an older version of Clang you can still use RTSan by directly linking in the runtime in directly.
 
-First, build the RTSan runtime by following the instructions in the [official docs](https://clang.llvm.org/docs/RealtimeSanitizer.html).
+## Getting the run-time libraries
 
-From there, find the RTSan runtime library and link it to your binary. This differs based on system:
+### Pre-built (recommended) 
+
+Pre-built versions of the runtime librarie can be downloaded from the [rtsan-libs](https://github.com/realtime-sanitizer/rtsan-libs/releases/latest)
+repository. Download the appropriate library for your architecture and link it to
+your binary.
+
+### Compiling from source
+
+You can otherwise build the RTSan runtime by following the instructions in the [official docs](https://clang.llvm.org/docs/RealtimeSanitizer.html).
+
+## Linking the RTSan runtime
+
+When you have built or downloaded the runtime library, simply link it to your binary. 
+This differs based on system:
 
 ```
 > cd $BUILD_DIR_MAC

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ RTSan is part of the LLVM project, starting from v20.0.0. Like other popular
 sanitizers, it uses a lightweight dynamic library that can detect real-time
 unsafe system library calls. Calls to functions such as `malloc`, `free` and
 `pthread_mutex_lock` (along with anything else RTSan believes may have a
-nondeterministic execution time) will cause RTSan to error, but only if they
+non-deterministic execution time) will cause RTSan to error, but only if they
 are called within a real-time context, as defined by the user. Real-time
 contexts are defined by the user simply by marking functions with the
 `[[clang::nonblocking]]` attribute.
@@ -125,7 +125,7 @@ setting the `CC` and `CXX` environment variables or ii) passing the
 `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` options to CMake as arguments.
 
 Adding the compile and link flag `-fsanitize=realtime` can be done however
-works best for your project. One unintrusive option is to pass them as
+works best for your project. One unobtrusive option is to pass them as
 arguments to CMake:
 
 ```sh
@@ -156,7 +156,7 @@ If you are in a position where you cannot use this compiler and instead rely on 
 
 ### Pre-built (recommended) 
 
-Pre-built versions of the runtime librarie can be downloaded from the [rtsan-libs](https://github.com/realtime-sanitizer/rtsan-libs/releases/latest)
+Pre-built versions of the runtime library can be downloaded from the [rtsan-libs](https://github.com/realtime-sanitizer/rtsan-libs/releases/latest)
 repository. Download the appropriate library for your architecture and link it to
 your binary.
 


### PR DESCRIPTION
I went in with the intention of updating the instructions for the pre-builts, but saw some other outdated things.